### PR TITLE
핫픽스: 취소 태그 도입 이전의 주문에 대한 취소태그 소급 적용

### DIFF
--- a/db/data/20200329135343_set_cancelled_tag_into_old_cancelled_cart_item.rb
+++ b/db/data/20200329135343_set_cancelled_tag_into_old_cancelled_cart_item.rb
@@ -1,0 +1,22 @@
+class SetCancelledTagIntoOldCancelledCartItem < ActiveRecord::Migration[6.0]
+  def up
+    ApplicationRecord.transaction do
+      PaperTrail.request(enabled: false) do
+        OrderInfo.unscoped.order_status('cancel-complete').each do |order|
+          order.cart.items.each do |cart_item|
+            next if cart_item.cancelled_tag
+
+            CartItemCancelledTag.create(
+              cart_item: cart_item,
+              cancelled_at: cart_item.cart.updated_at
+            )
+          end
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
- 데이터 마이그레이션을 추가했습니다. (cancelled_tag_into_old_cancelled_cart_item)